### PR TITLE
Code review

### DIFF
--- a/R/binary_two_arm_functions.R
+++ b/R/binary_two_arm_functions.R
@@ -203,9 +203,14 @@ beta_ineq_approx <- function(a, b, c, d, delta = 0) {
 beta_ineq_sim <- function(a, b, c, d, delta = 0, sims = 10000) {
   if(!(all(c(a, b, c, d) > 0))) stop("a, b, c, d must be > 0")
   
-  X <- stats::rbeta(sims, a, b)
-  Y <- stats::rbeta(sims, c, d)
-  mean(X > Y + delta)
+  lens <- unlist(lapply(list(a, b, c, d), length))
+  if(any(max(lens)- min(lens) != 0)) stop("a, b, c, d must be same len")
+  
+  X <- lapply(1:length(a), function(x) stats::rbeta(sims, a[x], b[x]))
+  Y <- lapply(1:length(a), function(x) stats::rbeta(sims, c[x], d[x]))
+  
+  means <- lapply(1:length(a), function(x) mean(X[[x]] > Y[[x]] + delta))
+  unlist(means)
 }
 
 #' Simulate trial data using Poisson process for accrual rate
@@ -227,7 +232,7 @@ sim_trial_dat <- function(
   enro_intensity = function(t) 1,
   resp_delay = function(n) runif(n)
 ) {
-  require(poisson)
+  library(poisson)
   require(data.table)
   require(randomizr)
   
@@ -258,6 +263,15 @@ sim_trial_dat <- function(
 #' @export
 agg_trial_dat <- function(d, stage_n, min_rem = 10) {
   resp_cut <- sort(d[, resp_t])[stage_n]
+  
+  # for all cutpoints, by group
+  # n participants with resp_time <= cut point
+  # y participants with events with resp_time <= cut point
+  # m participants enrolled but without resp_time available at cut point
+  # w participants with events that are enrolled but without resp_time available at cut point 
+  # l participants with enrolment occurring after cut point
+  # z participants with events with enrolment occurring after cut point
+  
   dd <- d[,
           {
             list(resp = stage_n,
@@ -269,6 +283,8 @@ agg_trial_dat <- function(d, stage_n, min_rem = 10) {
                  z = sapply(resp_cut, function(a) sum((enro_t > a)*y))
             )
           }, by = .(p1tru, p2tru, x)]
+  
+  # spread to wide.
   dcast(dd, resp + p1tru + p2tru ~ x, 
         value.var = c("n", "y", "m", "w", "l", "z"), sep = "")[(l1 + l2) > min_rem | resp == max(stage_n)]
 }
@@ -317,7 +333,7 @@ est_trial_prob <- function(
            a2 = a2 + y2,
            b2 = a2 + n2 - y2)]
   # Calculate posterior probabilities given current data and assuming follow-up of currently enrolled
-  d[, `:=`(post = calc_post(a1, b1, a2, b2),
+  d[, `:=`(post = calc_post(a1[1:.N], b1[1:.N], a2[1:.N], b2[1:.N]),
            post_int = calc_post(a1 + w1, b1 + m1 - w1, a2 + w2, b2 + m2 - w2))]
   d[, post_fin := post[.N]]
   
@@ -362,11 +378,11 @@ dec_trial <- function(
   fut_k = 0.1,
   suc_k = 0.9,
   inf_k = 0.05,
-  sup_k = 0.95) {
+  sup_k = 0.95, ...) {
   
   # Use the ppos column which matches sup_k
   ppos_cols <- grep(paste0(sup_k, "$"), names(trial), value = T)
-  if(length(ppos_cols) == 0 & ppos) stop("sup_k did not match any columns in trial.")
+  if(length(ppos_cols) == 0) stop("sup_k did not match any columns in trial.")
   max_stage <- trial[, .N, by = sim_id][, max(N)]
   
   if (length(fut_k) == 1)
@@ -378,6 +394,7 @@ dec_trial <- function(
   if (length(suc_k) < (max_stage - 1))
     stop("suc_k has too few elements")
   
+
   trial[,
         {
           fut <- match(TRUE, get(ppos_cols[2])[-.N] < fut_k[1:(.N-1)])

--- a/R/binary_two_arm_functions.R
+++ b/R/binary_two_arm_functions.R
@@ -333,7 +333,7 @@ est_trial_prob <- function(
            a2 = a2 + y2,
            b2 = a2 + n2 - y2)]
   # Calculate posterior probabilities given current data and assuming follow-up of currently enrolled
-  d[, `:=`(post = calc_post(a1[1:.N], b1[1:.N], a2[1:.N], b2[1:.N]),
+  d[, `:=`(post = calc_post(a1, b1, a2, b2),
            post_int = calc_post(a1 + w1, b1 + m1 - w1, a2 + w2, b2 + m2 - w2))]
   d[, post_fin := post[.N]]
   

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,7 @@
+library(optimum)
+library(data.table)
+
+
+
+test_check("orvacsim")
+

--- a/tests/testthat/test_optimum.R
+++ b/tests/testthat/test_optimum.R
@@ -1,0 +1,76 @@
+library(testthat)
+library(optimum)
+library(data.table)
+
+
+context("post approx")
+
+
+
+
+test_that("post probs approx similar", {
+  
+  simdat <- lapply(1, sim_trial_dat, p1tru = 0.2, p2tru = 0.1)
+  aggdat <- lapply(simdat, agg_trial_dat, stage_n = c(25, 50, 75, 100))
+  
+  a1 = 1; b1 = 1; a2 = 1; b2 = 1
+  
+  d <- copy(aggdat[[1]])
+  d1 <- copy(aggdat[[1]])
+  d2 <- copy(aggdat[[1]])
+  d3 <- copy(aggdat[[1]])
+  
+  calc_post <- beta_ineq_approx
+  # Determine posterior parameters
+  d1[, `:=`(a1 = a1 + y1,
+           b1 = b1 + n1 - y1,
+           a2 = a2 + y2,
+           b2 = a2 + n2 - y2)]
+  # Calculate posterior probabilities given current data and assuming follow-up of currently enrolled
+  d1[, `:=`(post = calc_post(a1, b1, a2, b2),
+           post_int = calc_post(a1 + w1, b1 + m1 - w1, a2 + w2, b2 + m2 - w2))]
+  d1[, post_fin := post[.N]]
+  d1
+  
+  calc_post <- beta_ineq
+  # Determine posterior parameters
+  d2[, `:=`(a1 = a1 + y1,
+            b1 = b1 + n1 - y1,
+            a2 = a2 + y2,
+            b2 = a2 + n2 - y2)]
+  # Calculate posterior probabilities given current data and assuming follow-up of currently enrolled
+  d2[, `:=`(post = calc_post(a1, b1, a2, b2),
+            post_int = calc_post(a1 + w1, b1 + m1 - w1, a2 + w2, b2 + m2 - w2))]
+  d2[, post_fin := post[.N]]
+  d2
+  
+  
+  calc_post <- beta_ineq_sim
+  # Determine posterior parameters
+  d3[, `:=`(a1 = a1 + y1,
+            b1 = b1 + n1 - y1,
+            a2 = a2 + y2,
+            b2 = a2 + n2 - y2)]
+  # Calculate posterior probabilities given current data and assuming follow-up of currently enrolled
+  d3[, `:=`(post = calc_post(a1, b1, a2, b2),
+            post_int = calc_post(a1 + w1, b1 + m1 - w1, a2 + w2, b2 + m2 - w2))]
+  d3[, post_fin := post[.N]]
+  d3
+  
+  #
+  expect_equal(d1$post, d2$post, tolerance = 0.01)
+  expect_equal(d1$post, d3$post, tolerance = 0.01)
+  expect_equal(d2$post, d3$post, tolerance = 0.01)
+  
+  #
+  expect_equal(d1$post_int, d2$post_int, tolerance = 0.01)
+  expect_equal(d1$post_int, d3$post_int, tolerance = 0.01)
+  expect_equal(d2$post_int, d3$post_int, tolerance = 0.01)
+  
+  #
+  expect_equal(d1$post_fin, d2$post_fin, tolerance = 0.01)
+  expect_equal(d1$post_fin, d3$post_fin, tolerance = 0.01)
+  expect_equal(d2$post_fin, d3$post_fin, tolerance = 0.01)
+})
+
+

--- a/tests/testthat/test_optimum.R
+++ b/tests/testthat/test_optimum.R
@@ -6,7 +6,21 @@ library(data.table)
 context("post approx")
 
 
+test_that("post probs", {
+  
+  simdat <- lapply(1, sim_trial_dat, p1tru = 0.2, p2tru = 0.1)
+  aggdat <- lapply(simdat, agg_trial_dat, stage_n = c(25, 50, 75, 100))
+  prbdat1 <- lapply(aggdat, est_trial_prob, ppos_q = c(0.95, 0.975), post_method = "approx")
+  
+  aggdat <- lapply(simdat, agg_trial_dat, stage_n = c(25, 50, 75, 100))
+  prbdat2 <- lapply(aggdat, est_trial_prob, ppos_q = c(0.95, 0.975), post_method = "sim")
+  
+  print(list(prbdat1, prbdat2))
 
+  expect_equal(prbdat1[[1]]$post, prbdat2[[1]]$post, tolerance = 0.05)
+  expect_equal(prbdat1[[1]]$post_int, prbdat2[[1]]$post_int, tolerance = 0.05)
+  expect_equal(prbdat1[[1]]$post_fin, prbdat2[[1]]$post_fin, tolerance = 0.05)
+})
 
 test_that("post probs approx similar", {
   

--- a/vignettes/optimum-example.Rmd
+++ b/vignettes/optimum-example.Rmd
@@ -29,7 +29,7 @@ Basic usage
 ```{r data}
 simdat <- lapply(1:10, sim_trial_dat, p1tru = 0.2, p2tru = 0.1)
 aggdat <- lapply(simdat, agg_trial_dat, stage_n = c(25, 50, 75, 100))
-prbdat <- lapply(aggdat, est_trial_prob, ppos_q = c(0.95, 0.975))
+prbdat <- lapply(aggdat, est_trial_prob, ppos_q = c(0.95, 0.975), post_method = "approx")
 decdat1 <- rbindlist(lapply(prbdat, dec_trial, sup_k = 0.95), idcol = "sim_id")
 decdat2 <- rbindlist(lapply(prbdat, dec_trial, sup_k = 0.975), idcol = "sim_id")
 ```


### PR DESCRIPTION
Hi James,
Nice implementation. Couple of (minor) things below. 
sim_trial_dat: no comments
agg_trial_dat: no comments
est_trial_prob:	I am not sure if this is important (or even maybe just an artefact of my globalenv) but if I switch calc_post from approx. to exact or sim, I get quite different values for post, post_int. Also, all the interims are given the same value, e.g.
> d
   resp p1tru p2tru n1 n2 y1 y2 m1 m2 w1 w2 l1 l2 z1 z2 a1 b1 a2 b2   post post_int
1:   25   0.2   0.1 12 13  2  0  0  0  0  0 38 37  7  3  3 11  1 14 0.8267   0.8323
2:   50   0.2   0.1 26 24  3  2  0  1  0  0 24 25  6  1  4 24  3 23 0.8267   0.8323
3:   75   0.2   0.1 36 39  4  2  0  1  0  0 14 10  5  1  5 33  3 38 0.8267   0.8323
4:  100   0.2   0.1 50 50  9  3  0  0  0  0  0  0  0  0 10 42  4 48 0.8267   0.8323
I think it has something to do with the way that a1, b1 etc are handled in beta_ineq_sim and have put an ungainly ‘fix’ in for beta_ineq_sim
Also, am wondering why does the for loop go up to nrow(d)-1 rather than nrow(d)?

dec_trial:	Where is ppos (line 385) defined? 
beta_ineq_sim	See above.
beta_ineq_approx	Aside: https://www.johndcook.com/blog/normal_approx_to_beta/ 
Actually, just the reference - Wise   Biometrika vol 47, No. 1/2, June 1960, pp. 173-175. If X is a beta(a, b) random variable with a ≥ b, (-log X)1/3 is more nearly normal than X is.

Finally, maybe use library to load packages rather than require, see:
https://yihui.name/en/2014/07/library-vs-require/

Let me know if you need further detail.
Thanks
M




